### PR TITLE
Rename form to checkout_form in one_page_checkout.html

### DIFF
--- a/lfs_theme/templates/lfs/checkout/one_page_checkout.html
+++ b/lfs_theme/templates/lfs/checkout/one_page_checkout.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block wrapper %}
-    {% if form.errors %}
+    {% if checkout_form.errors %}
         <div class="form-errors">
             {% trans "The operation could not be performed because one or more errors occurred. Please see below." %}
         </div>


### PR DESCRIPTION
Error messages in checkout_form not shown as form variable doesn't exist in one_page_checkout.html
